### PR TITLE
translate(error): multiple_error_types and option_unwrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ book
 
 # Auto-generated files from macOS
 .DS_Store
+
+.idea

--- a/src/error/multiple_error_types.md
+++ b/src/error/multiple_error_types.md
@@ -1,1 +1,36 @@
 # Multiple error types
+
+Các ví dụ trước luôn rất thuận tiện; những `Result` tương tác với
+những `Result`, trong khi những `Option` cũng tương tác với những `Option`.
+
+Đôi khi `Option` lại cần tương tác với `Result`, hoặc
+`Result<T, Error1>` cần tương tác với `Result<T, Error2>`. Trong những trường hợp đó,
+ta muốn quản lý các loại lỗi khác nhau sao cho những lỗi đó có thể kết hợp được với nhau và dễ dàng tương tác.
+
+
+Trong đoạn code sau, 2 trường hợp gọi `unwrap` trả về 2 loại lỗi khác nhau.
+`Vec::first` trả về `Option`, trong khi `parse::<i32>` trả về
+`Result<i32, ParseIntError>`:
+
+```rust,editable,ignore,mdbook-runnable
+fn double_first(vec: Vec<&str>) -> i32 {
+    let first = vec.first().unwrap(); // Trả về loại lỗi 1
+    2 * first.parse::<i32>().unwrap() // Trả về loại lỗi 2
+}
+
+fn main() {
+    let numbers = vec!["42", "93", "18"];
+    let empty = vec![];
+    let strings = vec!["tofu", "93", "18"];
+
+    println!("The first doubled is {}", double_first(numbers));
+
+    println!("The first doubled is {}", double_first(empty));
+    // Loại lỗi 1: vectơ đầu vào rỗng
+
+    println!("The first doubled is {}", double_first(strings));
+    // Loại lỗi 2: phần tử không thể chuyển đổi thành một số
+}
+```
+
+Trong các phần tiếp theo, chúng ta sẽ thấy một vài phương pháp để xử lý những vấn đề như như trên.

--- a/src/error/option_unwrap.md
+++ b/src/error/option_unwrap.md
@@ -1,1 +1,64 @@
 # Option & unwrap
+
+Trong ví dụ trước, ta thấy rằng ta có thể tạo ra lỗi chương trình theo ý muốn.
+Ta đã cho chương trình `panic` nếu ta uống nước chanh có đường.
+Nhưng nếu ta mong đợi một loại đồ uống nhưng lại không nhận được gì thì sao?
+Trường hợp đó cũng tệ không kém, vì vậy nó cần phải được xử lý!
+
+Chúng ta có thể kiểm tra điều này với string rỗng (`""`) giống như ta đã làm với nước chanh.
+Vì ta đang dùng Rust, hãy để compiler chỉ ra các trường hợp không có đồ uống.
+
+Một `enum` tên là `Option<T>` trong thư viện `std` được sử dụng trong trường hợp có thể không có một phần tử nào.
+Nó có dạng một trong hai "tuỳ chọn":
+
+* `Some(T)`: Một phần tử của kiểu `T` được tìm thấy
+* `None`: Không tìm thấy phần tử nào.
+
+Các trường hợp này có thể được xử lý một cách rõ ràng thông qua `match` hoặc một cách ngầm định thông qua
+`unwrap`. Xử lý ngầm định sẽ trả về phần tử bên trong hoặc `panic`.
+
+Lưu ý rằng có thể tùy chỉnh `panic` bằng cách sử dụng [expect][expect],
+nhưng xử lý ngầm định (`unwrap`) sẽ để lại cho ta một kết quả ít có ý nghĩa hơn so với việc xử lý rõ ràng.
+Trong ví dụ sau đây, việc xử lý rõ ràng giúp ta kiểm soát kết quả hơn,
+trong khi ta vẫn có thể `panic` nếu cần.
+
+```rust,editable,ignore,mdbook-runnable
+// Người lớn (adult) thì cái gì cũng uống được.
+// Mọi loại đồ uống đều được xử lý rõ ràng bằng cách sử dụng `match`.
+fn give_adult(drink: Option<&str>) {
+    // Mỗi đồ uống sẽ tương ứng với một hành động cụ thể.
+    match drink {
+        Some("lemonade") => println!("Yuck! Too sugary."),
+        Some(inner)   => println!("{}? How nice.", inner),
+        None          => println!("No drink? Oh well."),
+    }
+}
+
+// Những người còn lại (không phải người lớn) sẽ `panic` khi uống một loại đồ uống có đường.
+// Mọi loại đồ uống đều được xử lý ngầm định bằng cách sử dụng `unwrap`.
+fn drink(drink: Option<&str>) {
+    // `unwrap` trả lại `panic` khi nó nhận được `None`.
+    let inside = drink.unwrap();
+    if inside == "lemonade" { panic!("AAAaaaaa!!!!"); }
+
+    println!("I love {}s!!!!!", inside);
+}
+
+fn main() {
+    let water  = Some("water");
+    let lemonade = Some("lemonade");
+    let void  = None;
+
+    give_adult(water);
+    give_adult(lemonade);
+    give_adult(void);
+
+    let coffee = Some("coffee");
+    let nothing = None;
+
+    drink(coffee);
+    drink(nothing);
+}
+```
+
+[expect]: https://doc.rust-lang.org/std/option/enum.Option.html#method.expect

--- a/src/error/option_unwrap.md
+++ b/src/error/option_unwrap.md
@@ -18,7 +18,7 @@ Các trường hợp này có thể được xử lý một cách rõ ràng thô
 `unwrap`. Xử lý ngầm định sẽ trả về phần tử bên trong hoặc `panic`.
 
 Lưu ý rằng có thể tùy chỉnh `panic` bằng cách sử dụng [expect][expect],
-nhưng xử lý ngầm định (`unwrap`) sẽ để lại cho ta một kết quả ít có ý nghĩa hơn so với việc xử lý rõ ràng.
+nhưng xử lý ngầm định (`unwrap`) sẽ trả lại cho ta một kết quả ít có ý nghĩa hơn so với việc xử lý rõ ràng.
 Trong ví dụ sau đây, việc xử lý rõ ràng giúp ta kiểm soát kết quả tốt hơn,
 trong khi vẫn giữ tùy chọn `panic` nếu cần.
 

--- a/src/error/option_unwrap.md
+++ b/src/error/option_unwrap.md
@@ -6,7 +6,7 @@ Nhưng nếu ta mong đợi một loại đồ uống nhưng lại không nhận
 Trường hợp đó cũng tệ không kém, vì vậy nó cần phải được xử lý!
 
 Chúng ta có thể kiểm tra điều này với empty string (`""`) giống như ta đã làm với nước chanh.
-Vì ta đang dùng Rust, hãy để compiler chỉ ra các trường hợp không có đồ uống.
+Vì ta đang dùng Rust, hãy để compiler (trình biên dịch) chỉ ra các trường hợp không có đồ uống.
 
 Một `enum` tên là `Option<T>` trong thư viện `std` được sử dụng trong trường hợp có thể không có phần tử kiểu T.
 Nó có dạng một trong hai "tuỳ chọn":

--- a/src/error/option_unwrap.md
+++ b/src/error/option_unwrap.md
@@ -8,7 +8,7 @@ Trường hợp đó cũng tệ không kém, vì vậy nó cần phải được
 Chúng ta có thể kiểm tra điều này với empty string (`""`) giống như ta đã làm với nước chanh.
 Vì ta đang dùng Rust, hãy để compiler chỉ ra các trường hợp không có đồ uống.
 
-Một `enum` tên là `Option<T>` trong thư viện `std` được sử dụng trong trường hợp có thể không có một phần tử nào.
+Một `enum` tên là `Option<T>` trong thư viện `std` được sử dụng trong trường hợp có thể không có phần tử kiểu T.
 Nó có dạng một trong hai "tuỳ chọn":
 
 * `Some(T)`: Một phần tử của kiểu `T` được tìm thấy

--- a/src/error/option_unwrap.md
+++ b/src/error/option_unwrap.md
@@ -5,7 +5,7 @@ Ta đã cho chương trình `panic` nếu ta uống nước chanh có đường.
 Nhưng nếu ta mong đợi một loại đồ uống nhưng lại không nhận được gì thì sao?
 Trường hợp đó cũng tệ không kém, vì vậy nó cần phải được xử lý!
 
-Chúng ta có thể kiểm tra điều này với string rỗng (`""`) giống như ta đã làm với nước chanh.
+Chúng ta có thể kiểm tra điều này với empty string (`""`) giống như ta đã làm với nước chanh.
 Vì ta đang dùng Rust, hãy để compiler chỉ ra các trường hợp không có đồ uống.
 
 Một `enum` tên là `Option<T>` trong thư viện `std` được sử dụng trong trường hợp có thể không có một phần tử nào.
@@ -19,8 +19,8 @@ Các trường hợp này có thể được xử lý một cách rõ ràng thô
 
 Lưu ý rằng có thể tùy chỉnh `panic` bằng cách sử dụng [expect][expect],
 nhưng xử lý ngầm định (`unwrap`) sẽ để lại cho ta một kết quả ít có ý nghĩa hơn so với việc xử lý rõ ràng.
-Trong ví dụ sau đây, việc xử lý rõ ràng giúp ta kiểm soát kết quả hơn,
-trong khi ta vẫn có thể `panic` nếu cần.
+Trong ví dụ sau đây, việc xử lý rõ ràng giúp ta kiểm soát kết quả tốt hơn,
+trong khi vẫn giữ tùy chọn `panic` nếu cần.
 
 ```rust,editable,ignore,mdbook-runnable
 // Người lớn (adult) thì cái gì cũng uống được.


### PR DESCRIPTION
Closes: #21

2 file gốc:

[multiple_error_types.md](https://github.com/nebula-labs/rust-by-example-vn/blob/main/src/error/multiple_error_types.md)
[option_unwrap.md](https://github.com/nebula-labs/rust-by-example-vn/blob/main/src/error/option_unwrap.md)