### PR TITLE
Translate fn/closures

### DIFF
--- a/src/fn/closures/anonymity.md
+++ b/src/fn/closures/anonymity.md
@@ -1,1 +1,56 @@
 # Type anonymity
+
+Closures succinctly capture variables from enclosing scopes. Does this have
+any consequences? It surely does. Observe how using a closure as a function
+parameter requires [generics], which is necessary because of how they are
+defined:
+
+```rust
+// `F` must be generic.
+fn apply<F>(f: F) where
+    F: FnOnce() {
+    f();
+}
+```
+
+When a closure is defined, the compiler implicitly creates a new
+anonymous structure to store the captured variables inside, meanwhile
+implementing the functionality via one of the `traits`: `Fn`, `FnMut`, or
+`FnOnce` for this unknown type. This type is assigned to the variable which
+is stored until calling.
+
+Since this new type is of unknown type, any usage in a function will require
+generics. However, an unbounded type parameter `<T>` would still be ambiguous
+and not be allowed. Thus, bounding by one of the `traits`: `Fn`, `FnMut`, or
+`FnOnce` (which it implements) is sufficient to specify its type.
+
+```rust,editable
+// `F` must implement `Fn` for a closure which takes no
+// inputs and returns nothing - exactly what is required
+// for `print`.
+fn apply<F>(f: F) where
+    F: Fn() {
+    f();
+}
+
+fn main() {
+    let x = 7;
+
+    // Capture `x` into an anonymous type and implement
+    // `Fn` for it. Store it in `print`.
+    let print = || println!("{}", x);
+
+    apply(print);
+}
+```
+
+### See also:
+
+[A thorough analysis][thorough_analysis], [`Fn`][fn], [`FnMut`][fn_mut],
+and [`FnOnce`][fn_once]
+
+[generics]: ../../generics.md
+[fn]: https://doc.rust-lang.org/std/ops/trait.Fn.html
+[fn_mut]: https://doc.rust-lang.org/std/ops/trait.FnMut.html
+[fn_once]: https://doc.rust-lang.org/std/ops/trait.FnOnce.html
+[thorough_analysis]: https://huonw.github.io/blog/2015/05/finding-closure-in-rust/

--- a/src/fn/closures/anonymity.md
+++ b/src/fn/closures/anonymity.md
@@ -1,33 +1,24 @@
 # Type anonymity
 
-Closures succinctly capture variables from enclosing scopes. Does this have
-any consequences? It surely does. Observe how using a closure as a function
-parameter requires [generics], which is necessary because of how they are
-defined:
+Closures succinctly capture variables from enclosing scopes. Điều này có bất kì hậu quả gì không? Chắc chắn là có. Observe bằng cách sử dụng một closure như là một function parameter yêu cầu là [generics], điều này là cần thiết vì các chúng được định nghĩa:
 
 ```rust
-// `F` must be generic.
+// `F` phải là một generic.
 fn apply<F>(f: F) where
     F: FnOnce() {
     f();
 }
 ```
 
-When a closure is defined, the compiler implicitly creates a new
-anonymous structure to store the captured variables inside, meanwhile
-implementing the functionality via one of the `traits`: `Fn`, `FnMut`, or
-`FnOnce` for this unknown type. This type is assigned to the variable which
-is stored until calling.
+Khi một closure được định nghĩa, compiler mặc nhiên tạo ra một kiểu cấu trúc không xác định mới để lưu giữ các biến bên trong, trong lúc triển khai các chức năng qua một kiểu `traits` là: `Fn`, `FnMut`, hoặc
+`FnOnce` cho một kiểu không xác định này. Kiểu dữ liệu này được gán cho biến được lưu trữ khi gọi đến.
 
-Since this new type is of unknown type, any usage in a function will require
-generics. However, an unbounded type parameter `<T>` would still be ambiguous
-and not be allowed. Thus, bounding by one of the `traits`: `Fn`, `FnMut`, or
-`FnOnce` (which it implements) is sufficient to specify its type.
+Vì kiểu dữ liệu mới này là kiểu dữ liệu không xác định, bất kì cách sử dụng nào trong một function sẽ yêu cầu kiểu generics. Tuy nhiên, một tham số kiểu không giới hạn(unbounded) `<T>` vẫn sẽ là mơ hồ và không được phép. Như vậy, giới hạn bởi một trong các kiểu `traits` là: `Fn`, `FnMut`, hoặc
+`FnOnce` (kiểu nó được triển khai) là đủ để xác định loại của nó.
 
 ```rust,editable
-// `F` must implement `Fn` for a closure which takes no
-// inputs and returns nothing - exactly what is required
-// for `print`.
+// `F` phải triển khai `Fn` cho một closure mà không có inputs
+// và không trả lại cái gì - chính xác những gì được yêu cầu là `print`
 fn apply<F>(f: F) where
     F: Fn() {
     f();
@@ -36,8 +27,8 @@ fn apply<F>(f: F) where
 fn main() {
     let x = 7;
 
-    // Capture `x` into an anonymous type and implement
-    // `Fn` for it. Store it in `print`.
+    // Capture `x` vào một kiểu ẩn danh và triển khai `Fn` cho nó
+    // Lưu trữ nó trong `print`.
     let print = || println!("{}", x);
 
     apply(print);

--- a/src/fn/closures/anonymity.md
+++ b/src/fn/closures/anonymity.md
@@ -12,7 +12,7 @@ fn apply<F>(f: F) where
 
 Khi một closure được định nghĩa, compiler tự động tạo ra một kiểu cấu trúc không xác định mới để lưu giữ các biến bên trong closure, trong khi đó, triển khai chức năng thông qua một trong các `traits`: `Fn`, `FnMut`, hoặc `FnOnce` cho kiểu không xác định đó. Kiểu dữ liệu này được gán cho biến và được lưu trữ khi gọi đến.
 
-Vì kiểu dữ liệu mới này là kiểu dữ liệu không xác định, bất kì cách sử dụng nào trong một function sẽ yêu cầu kiểu generics. Tuy nhiên, một tham số kiểu không giới hạn(unbounded) `<T>` vẫn sẽ là mơ hồ và không được phép. Vì vậy, ràng buộc bởi một trong các `traits`: `Fn`, `FnMut`, hoặc
+Vì kiểu dữ liệu mới này là kiểu dữ liệu không xác định, bất kì khi nào sử dụng trong một function sẽ yêu cầu kiểu generics. Tuy nhiên, một tham số kiểu không giới hạn(unbounded) `<T>` vẫn sẽ là mơ hồ và không được phép. Vì vậy, ràng buộc bởi một trong các `traits`: `Fn`, `FnMut`, hoặc
 `FnOnce` (kiểu nó được triển khai) là đủ để xác định kiểu của nó.
 
 ```rust,editable

--- a/src/fn/closures/anonymity.md
+++ b/src/fn/closures/anonymity.md
@@ -1,6 +1,6 @@
 # Type anonymity
 
-Closures succinctly capture variables from enclosing scopes. Điều này có bất kì hậu quả gì không? Chắc chắn là có. Observe bằng cách sử dụng một closure như là một function parameter yêu cầu là [generics], điều này là cần thiết vì các chúng được định nghĩa:
+Closure (đóng gói) nhắm gọn các biến từ phạm vi bao quanh một cách ngắn gọn. Điều này có gây ra bất kỳ hệ quả gì không? Chắc chắn là có. Dễ thấy rằng sử dụng một closure như một tham số của hàm đòi hỏi sử dụng [generics], điều này cần thiết bởi cách chúng được định nghĩa:
 
 ```rust
 // `F` phải là một generic.
@@ -10,15 +10,14 @@ fn apply<F>(f: F) where
 }
 ```
 
-Khi một closure được định nghĩa, compiler mặc nhiên tạo ra một kiểu cấu trúc không xác định mới để lưu giữ các biến bên trong, trong lúc triển khai các chức năng qua một kiểu `traits` là: `Fn`, `FnMut`, hoặc
-`FnOnce` cho một kiểu không xác định này. Kiểu dữ liệu này được gán cho biến được lưu trữ khi gọi đến.
+Khi một closure được định nghĩa, compiler tự động tạo ra một kiểu cấu trúc không xác định mới để lưu giữ các biến bên trong closure, trong khi đó, triển khai chức năng thông qua một trong các `traits`: `Fn`, `FnMut`, hoặc `FnOnce` cho kiểu không xác định đó. Kiểu dữ liệu này được gán cho biến và được lưu trữ khi gọi đến.
 
-Vì kiểu dữ liệu mới này là kiểu dữ liệu không xác định, bất kì cách sử dụng nào trong một function sẽ yêu cầu kiểu generics. Tuy nhiên, một tham số kiểu không giới hạn(unbounded) `<T>` vẫn sẽ là mơ hồ và không được phép. Như vậy, giới hạn bởi một trong các kiểu `traits` là: `Fn`, `FnMut`, hoặc
-`FnOnce` (kiểu nó được triển khai) là đủ để xác định loại của nó.
+Vì kiểu dữ liệu mới này là kiểu dữ liệu không xác định, bất kì cách sử dụng nào trong một function sẽ yêu cầu kiểu generics. Tuy nhiên, một tham số kiểu không giới hạn(unbounded) `<T>` vẫn sẽ là mơ hồ và không được phép. Vì vậy, ràng buộc bởi một trong các `traits`: `Fn`, `FnMut`, hoặc
+`FnOnce` (kiểu nó được triển khai) là đủ để xác định kiểu của nó.
 
 ```rust,editable
 // `F` phải triển khai `Fn` cho một closure mà không có inputs
-// và không trả lại cái gì - chính xác những gì được yêu cầu là `print`
+// và không trả lại gì cả - chính xác những gì được yêu cầu cho `print`
 fn apply<F>(f: F) where
     F: Fn() {
     f();
@@ -27,7 +26,7 @@ fn apply<F>(f: F) where
 fn main() {
     let x = 7;
 
-    // Capture `x` vào một kiểu ẩn danh và triển khai `Fn` cho nó
+    // Capture `x` vào một kiểu không xách định và triển khai `Fn` cho nó
     // Lưu trữ nó trong `print`.
     let print = || println!("{}", x);
 

--- a/src/fn/closures/capture.md
+++ b/src/fn/closures/capture.md
@@ -1,13 +1,13 @@
 # Capturing
 
-Closures vốn dĩ linh hoạt và sẽ làm bất cứ điều gì mà function yêu cầu để làm cho closure hoạt động mà không cần chú thích(annotation). Điều này cho phép capturing thích ứng với các trường hợp sử dụng(use case), đôi khi moving và đôi khi borrowing.
-Closures có thể capture các biến thông qua:
+Closures có tính linh hoạt và sẽ thực hiện bất cứ điều gì mà function yêu cầu để làm cho closure hoạt động mà không cần chú thích(annotation). Điều này cho phép việc capturing(khi khai báo closure) thích nghi với các trường hợp sử dụng(use case), đôi khi sử dụng moving và borrowing.
+Closures có thể capture(khai báo) các biến thông qua:
 
 * bằng tham chiếu: `&T`
 * bằng tham chiếu có thể thay đổi: `&mut T`
 * bằng giá trị: `T`
 
-Chúng ưu tiên capture các biến qua tham chiếu và chỉ đi xuống thấp hơn khi được yêu cầu.
+Chúng ưu tiên capture biến bằng tham chiếu và chỉ đi sử dụng cách thấp hơn khi cần thiết.
 
 ```rust,editable
 fn main() {
@@ -15,77 +15,70 @@ fn main() {
     
     let color = String::from("green");
 
-    // A closure to print `color` which immediately borrows (`&`) `color` and
-    // stores the borrow and closure in the `print` variable. It will remain
-    // borrowed until `print` is used the last time. 
-    //
-    // `println!` only requires arguments by immutable reference so it doesn't
-    // impose anything more restrictive.
+    // Một closure để print `color` sẽ ngay lập tức mượn(borrows) (`&`) `color` và
+    // lưu borrow và closure vào trong biến `print`. Nó vẫn sẽ được borrow cho đến khi `print` được sử dụng lần cuối 
+    // `println!` chỉ yêu cầu đối số bằng tham chiếu không thể thay đổi(immutable) vì vậy nó không đặt ra bất cứ hạn chế nào khác.
     let print = || println!("`color`: {}", color);
 
-    // Call the closure using the borrow.
+    // Gọi closure bằng cách sử dụng borrow.
     print();
 
-    // `color` can be borrowed immutably again, because the closure only holds
-    // an immutable reference to `color`. 
+    // `color` có thể được mượn(borrow) một lần nữa bằng cách không thay đổi(immutably), vì closure chỉ giữ một tham chiếu không thể thay đổi(immutable) tới `color`. 
     let _reborrow = &color;
     print();
 
-    // A move or reborrow is allowed after the final use of `print`
+    // Một thao tác move hoặc reborrow được phép sau lần cuối cùng sử dụng `print`
     let _color_moved = color;
 
 
     let mut count = 0;
-    // A closure to increment `count` could take either `&mut count` or `count`
-    // but `&mut count` is less restrictive so it takes that. Immediately
-    // borrows `count`.
+    // Một closure để tăng giá trị của `count` có thể sử dụng `&mut count` hoặc `count`
+    // nhưng `&mut count` là hạn chế hơn so nên nó sẽ lấy tham chiếu đến `count`. Ngay lập tức borrows `count`.
     //
-    // A `mut` is required on `inc` because a `&mut` is stored inside. Thus,
-    // calling the closure mutates the closure which requires a `mut`.
+    // Cần thêm `mut` cho `inc` bởi vì một tham chiếu `&mut` được lưu dữ liệu bên trong. 
+    // Do đó, việc gọi closure làm thay đổi trong closure, điều này yêu cầu một `mut`.
     let mut inc = || {
         count += 1;
         println!("`count`: {}", count);
     };
 
-    // Call the closure using a mutable borrow.
+    // Gọi tới closure bằng cách sử dụng một mutable borrow.
     inc();
 
-    // The closure still mutably borrows `count` because it is called later.
-    // An attempt to reborrow will lead to an error.
+    // Closure vẫn mượn(borrows) `count` có thể thay đổi(mutably) bởi vì nó được gọi sau đó.
+    // Một nỗ lực để mượn lại(reborrow) sẽ dẫn đến một lỗi.
     // let _reborrow = &count; 
-    // ^ TODO: try uncommenting this line.
+    // ^ TODO: thử bỏ chú thích(uncommenting) dòng phía trên.
     inc();
 
-    // The closure no longer needs to borrow `&mut count`. Therefore, it is
-    // possible to reborrow without an error
+    // closure không cần phải mượn(borrow) `&mut count`. 
+    // Do đó, có thể mượn(reborrow) lại mà không gặp lỗi
     let _count_reborrowed = &mut count; 
 
     
-    // A non-copy type.
+    // Một kiểu dữ liệu không thể sao chép(A non-copy type).
     let movable = Box::new(3);
 
-    // `mem::drop` requires `T` so this must take by value. A copy type
-    // would copy into the closure leaving the original untouched.
-    // A non-copy must move and so `movable` immediately moves into
-    // the closure.
+    // `mem::drop` yêu cầu `T` phải truyền vào theo giá trị(take by value). 
+    // Một kiểu dữ liệu có thể sao chép (copy type) sẽ sao chép vào closure mà không làm thay đổi đối tượng ban đầu.
+    // Kiểu dữ liệu không thể sao chép phải được di chuyển(move) và do đó, `movable` sẽ được di chuyển ngay vào closure.
     let consume = || {
         println!("`movable`: {:?}", movable);
         mem::drop(movable);
     };
 
-    // `consume` consumes the variable so this can only be called once.
+    // biến `consume` chỉ có thể gọi một lần.
     consume();
     // consume();
-    // ^ TODO: Try uncommenting this line.
+    // ^ TODO: Thử bỏ chú thích(uncommenting) dòng phía trên.
 }
 ```
 
-Using `move` before vertical pipes forces closure
-to take ownership of captured variables:
+Sử dụng `move` trước dấu '||' thì closure sẽ buộc phải lấy quyền sở hữu(ownership) của các biến được capture:
 
 ```rust,editable
 fn main() {
-    // `Vec` has non-copy semantics.
+    // `Vec` có tính không thể sao chép (non-copy).
     let haystack = vec![1, 2, 3];
 
     let contains = move |needle| haystack.contains(needle);
@@ -94,13 +87,12 @@ fn main() {
     println!("{}", contains(&4));
 
     // println!("There're {} elements in vec", haystack.len());
-    // ^ Uncommenting above line will result in compile-time error
-    // because borrow checker doesn't allow re-using variable after it
-    // has been moved.
+    // ^ bỏ chú thích(uncommenting) dòng phía trên sẽ trả về lỗi compile
+    // bởi vì trình kiểm tra borrow checker không cho phép sử dụng lại biến sau khi nó đã được move.
     
-    // Removing `move` from closure's signature will cause closure
-    // to borrow _haystack_ variable immutably, hence _haystack_ is still
-    // available and uncommenting above line will not cause an error.
+    // Xóa `move` khỏi chữ kí của closure sẽ khiến closure
+    // mượn(borrow) biến _haystack_ một cách không thể thay đổi, do đó _haystack_ vẫn 
+    // khả dụng và bỏ chú thích(uncommenting) dòng trên sẽ không gây ra lỗi.
 }
 ```
 

--- a/src/fn/closures/capture.md
+++ b/src/fn/closures/capture.md
@@ -7,7 +7,7 @@ Closures có thể capture(khai báo) các biến thông qua:
 * bằng tham chiếu có thể thay đổi: `&mut T`
 * bằng giá trị: `T`
 
-Chúng ưu tiên capture biến bằng tham chiếu và chỉ đi sử dụng cách thấp hơn khi cần thiết.
+Chúng ưu tiên capture biến bằng tham chiếu và chỉ sử dụng các cách khác khi cần thiết.
 
 ```rust,editable
 fn main() {
@@ -15,8 +15,8 @@ fn main() {
     
     let color = String::from("green");
 
-    // Một closure để print `color` sẽ ngay lập tức mượn(borrows) (`&`) `color` và
-    // lưu borrow và closure vào trong biến `print`. Nó vẫn sẽ được borrow cho đến khi `print` được sử dụng lần cuối 
+    // Một closure để in ra biến `color` sẽ ngay lập tức mượn(borrows) (`&`) `color` và
+    // lưu borrow và closure vào trong biến `print`. Nó vẫn sẽ giữ borrow cho đến khi `print` được sử dụng lần cuối 
     // `println!` chỉ yêu cầu đối số bằng tham chiếu không thể thay đổi(immutable) vì vậy nó không đặt ra bất cứ hạn chế nào khác.
     let print = || println!("`color`: {}", color);
 
@@ -27,13 +27,13 @@ fn main() {
     let _reborrow = &color;
     print();
 
-    // Một thao tác move hoặc reborrow được phép sau lần cuối cùng sử dụng `print`
+    // Một thao tác move hoặc reborrow sẽ có thể được phép thực hiện sau lần cuối cùng sử dụng `print`
     let _color_moved = color;
 
 
     let mut count = 0;
     // Một closure để tăng giá trị của `count` có thể sử dụng `&mut count` hoặc `count`
-    // nhưng `&mut count` là hạn chế hơn so nên nó sẽ lấy tham chiếu đến `count`. Ngay lập tức borrows `count`.
+    // nhưng `&mut count` có ít hạn chế hơn cho nên closure sẽ chọn `&mut count`. Ngay lập tức borrows `count`.
     //
     // Cần thêm `mut` cho `inc` bởi vì một tham chiếu `&mut` được lưu dữ liệu bên trong. 
     // Do đó, việc gọi closure làm thay đổi trong closure, điều này yêu cầu một `mut`.
@@ -45,8 +45,8 @@ fn main() {
     // Gọi tới closure bằng cách sử dụng một mutable borrow.
     inc();
 
-    // Closure vẫn mượn(borrows) `count` có thể thay đổi(mutably) bởi vì nó được gọi sau đó.
-    // Một nỗ lực để mượn lại(reborrow) sẽ dẫn đến một lỗi.
+    // Closure vẫn mượn(borrows) `count` ở dạng có thể thay đổi(mutably) bởi vì nó được gọi sau đó.
+    // Nếu bạn thực hiện mượn lại(reborrow) sẽ dẫn đến một lỗi.
     // let _reborrow = &count; 
     // ^ TODO: thử bỏ chú thích(uncommenting) dòng phía trên.
     inc();

--- a/src/fn/closures/capture.md
+++ b/src/fn/closures/capture.md
@@ -1,6 +1,6 @@
 # Capturing
 
-Closures có tính linh hoạt và sẽ thực hiện bất cứ điều gì mà function yêu cầu để làm cho closure hoạt động mà không cần chú thích(annotation). Điều này cho phép việc capturing(khi khai báo closure) thích nghi với các trường hợp sử dụng(use case), đôi khi sử dụng moving và borrowing.
+Closures vốn rất linh hoạt và sẽ thực hiện bất cứ điều gì mà function yêu cầu để làm cho closure hoạt động mà không cần chú thích(annotation). Điều này cho phép việc capturing(khi khai báo closure) thích nghi với các trường hợp sử dụng(use case), đôi khi sử dụng moving và borrowing.
 Closures có thể capture(khai báo) các biến thông qua:
 
 * bằng tham chiếu: `&T`

--- a/src/fn/closures/capture.md
+++ b/src/fn/closures/capture.md
@@ -1,16 +1,13 @@
 # Capturing
 
-Closures are inherently flexible and will do what the functionality requires
-to make the closure work without annotation. This allows capturing to
-flexibly adapt to the use case, sometimes moving and sometimes borrowing.
-Closures can capture variables:
+Closures vốn dĩ linh hoạt và sẽ làm bất cứ điều gì mà function yêu cầu để làm cho closure hoạt động mà không cần chú thích(annotation). Điều này cho phép capturing thích ứng với các trường hợp sử dụng(use case), đôi khi moving và đôi khi borrowing.
+Closures có thể capture các biến thông qua:
 
-* by reference: `&T`
-* by mutable reference: `&mut T`
-* by value: `T`
+* bằng tham chiếu: `&T`
+* bằng tham chiếu có thể thay đổi: `&mut T`
+* bằng giá trị: `T`
 
-They preferentially capture variables by reference and only go lower when
-required.
+Chúng ưu tiên capture các biến qua tham chiếu và chỉ đi xuống thấp hơn khi được yêu cầu.
 
 ```rust,editable
 fn main() {

--- a/src/fn/closures/capture.md
+++ b/src/fn/closures/capture.md
@@ -1,1 +1,115 @@
 # Capturing
+
+Closures are inherently flexible and will do what the functionality requires
+to make the closure work without annotation. This allows capturing to
+flexibly adapt to the use case, sometimes moving and sometimes borrowing.
+Closures can capture variables:
+
+* by reference: `&T`
+* by mutable reference: `&mut T`
+* by value: `T`
+
+They preferentially capture variables by reference and only go lower when
+required.
+
+```rust,editable
+fn main() {
+    use std::mem;
+    
+    let color = String::from("green");
+
+    // A closure to print `color` which immediately borrows (`&`) `color` and
+    // stores the borrow and closure in the `print` variable. It will remain
+    // borrowed until `print` is used the last time. 
+    //
+    // `println!` only requires arguments by immutable reference so it doesn't
+    // impose anything more restrictive.
+    let print = || println!("`color`: {}", color);
+
+    // Call the closure using the borrow.
+    print();
+
+    // `color` can be borrowed immutably again, because the closure only holds
+    // an immutable reference to `color`. 
+    let _reborrow = &color;
+    print();
+
+    // A move or reborrow is allowed after the final use of `print`
+    let _color_moved = color;
+
+
+    let mut count = 0;
+    // A closure to increment `count` could take either `&mut count` or `count`
+    // but `&mut count` is less restrictive so it takes that. Immediately
+    // borrows `count`.
+    //
+    // A `mut` is required on `inc` because a `&mut` is stored inside. Thus,
+    // calling the closure mutates the closure which requires a `mut`.
+    let mut inc = || {
+        count += 1;
+        println!("`count`: {}", count);
+    };
+
+    // Call the closure using a mutable borrow.
+    inc();
+
+    // The closure still mutably borrows `count` because it is called later.
+    // An attempt to reborrow will lead to an error.
+    // let _reborrow = &count; 
+    // ^ TODO: try uncommenting this line.
+    inc();
+
+    // The closure no longer needs to borrow `&mut count`. Therefore, it is
+    // possible to reborrow without an error
+    let _count_reborrowed = &mut count; 
+
+    
+    // A non-copy type.
+    let movable = Box::new(3);
+
+    // `mem::drop` requires `T` so this must take by value. A copy type
+    // would copy into the closure leaving the original untouched.
+    // A non-copy must move and so `movable` immediately moves into
+    // the closure.
+    let consume = || {
+        println!("`movable`: {:?}", movable);
+        mem::drop(movable);
+    };
+
+    // `consume` consumes the variable so this can only be called once.
+    consume();
+    // consume();
+    // ^ TODO: Try uncommenting this line.
+}
+```
+
+Using `move` before vertical pipes forces closure
+to take ownership of captured variables:
+
+```rust,editable
+fn main() {
+    // `Vec` has non-copy semantics.
+    let haystack = vec![1, 2, 3];
+
+    let contains = move |needle| haystack.contains(needle);
+
+    println!("{}", contains(&1));
+    println!("{}", contains(&4));
+
+    // println!("There're {} elements in vec", haystack.len());
+    // ^ Uncommenting above line will result in compile-time error
+    // because borrow checker doesn't allow re-using variable after it
+    // has been moved.
+    
+    // Removing `move` from closure's signature will cause closure
+    // to borrow _haystack_ variable immutably, hence _haystack_ is still
+    // available and uncommenting above line will not cause an error.
+}
+```
+
+### See also:
+
+[`Box`][box] and [`std::mem::drop`][drop]
+
+[box]: ../../std/box.md
+[drop]: https://doc.rust-lang.org/std/mem/fn.drop.html


### PR DESCRIPTION
Closes: #29 


- [x] [anonymity.md](https://github.com/nebula-labs/rust-by-example-vn/blob/main/src/fn/closures/anonymity.md)
- [x] [capture.md](https://github.com/nebula-labs/rust-by-example-vn/blob/main/src/fn/closures/capture.md)