### PR TITLE
translate std_misc/process/ pipe.md + wait.md

### DIFF
--- a/src/std_misc/process/pipe.md
+++ b/src/std_misc/process/pipe.md
@@ -23,7 +23,7 @@ fn main() {
     // Truyền một chuỗi vào `stdin` của `wc`.
     //
     // `stdin` có kiểu là `Option<ChildStdin>`, nhưng vì chúng ta biết chắc rằng có một thể hiện của stdin
-    // must have one, we can directly `unwrap` it.
+    // tồn tại trong process, nên chúng ta có thể `unwrap` nó một cách trực tiếp.
     match process.stdin.unwrap().write_all(PANGRAM.as_bytes()) {
         Err(why) => panic!("couldn't write to wc stdin: {}", why),
         Ok(_) => println!("sent pangram to wc"),

--- a/src/std_misc/process/pipe.md
+++ b/src/std_misc/process/pipe.md
@@ -1,1 +1,44 @@
 # Pipes
+
+`std::Child` struct đại diện cho một tiến trình con đang chạy, và đưa ra các điều khiển
+`stdin`, `stdout` và `stderr` để tưởng tác với tiến trình thông qua pipes.
+
+```rust,ignore
+use std::io::prelude::*;
+use std::process::{Command, Stdio};
+
+static PANGRAM: &'static str =
+"the quick brown fox jumped over the lazy dog\n";
+
+fn main() {
+    // Khởi tạo câu lệnh `wc`
+    let process = match Command::new("wc")
+                                .stdin(Stdio::piped())
+                                .stdout(Stdio::piped())
+                                .spawn() {
+        Err(why) => panic!("couldn't spawn wc: {}", why),
+        Ok(process) => process,
+    };
+
+    // Truyền một chuỗi vào `stdin` của `wc`.
+    //
+    // `stdin` có kiểu là `Option<ChildStdin>`, but since we know this instance
+    // must have one, we can directly `unwrap` it.
+    match process.stdin.unwrap().write_all(PANGRAM.as_bytes()) {
+        Err(why) => panic!("couldn't write to wc stdin: {}", why),
+        Ok(_) => println!("sent pangram to wc"),
+    }
+
+    // Bởi vì `stdin` không tồn tại sau khi được gọi ở trên,
+    // nó được loại bỏ và pipe được đóng lại
+    //
+    // Điều này rất quan trọng, nếu không thì `wc` sẽ không bắt đầu xử lí dữ liệu được nhập vào
+
+    // `stdout` cũng có kiểu là `Option<ChildStdout>` nên cũng phải được unwrap.
+    let mut s = String::new();
+    match process.stdout.unwrap().read_to_string(&mut s) {
+        Err(why) => panic!("couldn't read wc stdout: {}", why),
+        Ok(_) => print!("wc responded with:\n{}", s),
+    }
+}
+```

--- a/src/std_misc/process/pipe.md
+++ b/src/std_misc/process/pipe.md
@@ -22,7 +22,7 @@ fn main() {
 
     // Truyền một chuỗi vào `stdin` của `wc`.
     //
-    // `stdin` có kiểu là `Option<ChildStdin>`, but since we know this instance
+    // `stdin` có kiểu là `Option<ChildStdin>`, nhưng vì chúng ta biết chắc rằng có một thể hiện của stdin
     // must have one, we can directly `unwrap` it.
     match process.stdin.unwrap().write_all(PANGRAM.as_bytes()) {
         Err(why) => panic!("couldn't write to wc stdin: {}", why),

--- a/src/std_misc/process/pipe.md
+++ b/src/std_misc/process/pipe.md
@@ -1,7 +1,7 @@
 # Pipes
 
 `std::Child` struct đại diện cho một tiến trình con đang chạy, và đưa ra các điều khiển
-`stdin`, `stdout` và `stderr` để tưởng tác với tiến trình thông qua pipes.
+`stdin`, `stdout` và `stderr` để tương tác với tiến trình thông qua pipes.
 
 ```rust,ignore
 use std::io::prelude::*;

--- a/src/std_misc/process/wait.md
+++ b/src/std_misc/process/wait.md
@@ -1,1 +1,21 @@
 # Wait
+
+Nếu bạn muốn đợi một `process::Child` kết thúc, thì phải gọi
+`Child::wait`, sẽ trả về một `process::ExitStatus`.
+
+```rust,ignore
+use std::process::Command;
+
+fn main() {
+    let mut child = Command::new("sleep").arg("5").spawn().unwrap();
+    let _result = child.wait().unwrap();
+
+    println!("reached end of main");
+}
+```
+
+```bash
+$ rustc wait.rs && ./wait
+# `wait` tiếp tục chạy thêm 5 giây cho tới khi câu lệnh `sleep 5` kết thúc
+reached end of main
+```

--- a/src/std_misc/process/wait.md
+++ b/src/std_misc/process/wait.md
@@ -1,7 +1,7 @@
 # Wait
 
 Nếu bạn muốn đợi một `process::Child` kết thúc, thì phải gọi
-`Child::wait`, sẽ trả về một `process::ExitStatus`.
+`Child::wait`, nó sẽ trả về một `process::ExitStatus`.
 
 ```rust,ignore
 use std::process::Command;


### PR DESCRIPTION
Close #89 

Có đoạn này chưa biết dịch như thế nào, nhờ mọi người góp ý

// `stdin` có kiểu là `Option<ChildStdin>`, but since we know this instance
// must have one, we can directly `unwrap` it.